### PR TITLE
Express server doesn't start because default ENV var names are wrong

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -4,10 +4,10 @@ const path = require("path");
 require("dotenv").config({ path: path.resolve(__dirname, "../.env") });
 
 const config = {
-  client_id: process.env.CLIENT_ID,
-  redirect_uri: process.env.REDIRECT_URI,
-  client_secret: process.env.CLIENT_SECRET,
-  proxy_url: process.env.PROXY_URL
+  client_id: process.env.REACT_APP_CLIENT_ID,
+  redirect_uri: process.env.REACT_APP_CLIENT_SECRET,
+  client_secret: process.env.REACT_APP_REDIRECT_URI,
+  proxy_url: process.env.REACT_APP_PROXY_URL
 };
 
 const envVarsSchema = Joi.object({


### PR DESCRIPTION
The app won't run when following the exact instructions in the readme.

It turns out this is because the ENV var names in the example .env don't match the ENV var names in the config.js, so the server fails to start.